### PR TITLE
SPEC file: Fixed checking for zstd support

### DIFF
--- a/dist/obs-service-recompress.spec
+++ b/dist/obs-service-recompress.spec
@@ -35,9 +35,7 @@ Requires:       bzip2
 Requires:       gzip
 Requires:       xz
 
-%if (0%{?suse_version} <= 1500 && 0%{?sle_version} <= 150000) || 0%{?fedora_version} < 25 || 0%{?rhel_version} < 6
-# noop
-%else
+%if 0%{?suse_version} > 1500 || 0%{?sle_version} > 150000 || 0%{?fedora_version} > 25 || 0%{?rhel} >= 6
 BuildRequires:  zstd
 Requires:       zstd
 %endif


### PR DESCRIPTION
The current spec file will never enable zstd, as the macro for noop is always true[1].
So instead of providing (a not working) noop for old system, enable it for known working systems.

Also CentOS does not set `rhel_version` but `rhel`.

[1] e.g. you are building on RHEL6:
```spec
%if (0%{?suse_version} <= 1500 && 0%{?sle_version} <= 150000) || 0%{?fedora_version} < 25 || 0%{?rhel_version} < 6
# will result in something like
%if (0 <= 1500 && 0 <= 150000) || 0 < 25 || 06 < 6
# result in
%if true || true || false
# will trigger noop
```
So even if the system support zstd, it does not get enabled.

